### PR TITLE
Add optional Workload Identity

### DIFF
--- a/modules/project/github.tf
+++ b/modules/project/github.tf
@@ -1,0 +1,38 @@
+resource "google_iam_workload_identity_pool" "github-actions" {
+  count = var.github_repository != null ? 1 : 0
+
+  project                   = var.project_id
+  workload_identity_pool_id = "github-actions"
+  display_name              = "GitHub Actions"
+  description               = "Identity pool for the GitHub actions"
+}
+
+resource "google_iam_workload_identity_pool_provider" "github-actions" {
+  count = var.github_repository != null ? 1 : 0
+
+  project                            = var.project_id
+  workload_identity_pool_id          = google_iam_workload_identity_pool.github-actions[0].workload_identity_pool_id
+  workload_identity_pool_provider_id = "github-actions"
+  display_name                       = "GitHub Actions"
+  description                        = "Identity pool provider for the GitHub actions"
+  attribute_mapping = {
+    "google.subject"       = "assertion.sub"
+    "attribute.actor"      = "assertion.actor"
+    "attribute.aud"        = "assertion.aud"
+    "attribute.repository" = "assertion.repository"
+  }
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+  attribute_condition = "assertion.repository=='${var.github_repository}'"
+}
+
+resource "google_service_account_iam_binding" "terraform" {
+  count = var.github_repository != null ? 1 : 0
+
+  service_account_id = google_service_account.terraform.name
+  role               = "roles/iam.workloadIdentityUser"
+  members = [
+    "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github-actions[0].name}/attribute.repository/${var.github_repository}"
+  ]
+}

--- a/modules/project/main.tf
+++ b/modules/project/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~>3.65"
+      version = "~>5.11"
     }
   }
 }

--- a/modules/project/outputs.tf
+++ b/modules/project/outputs.tf
@@ -16,3 +16,7 @@ output "number" {
 output "terraform_service_account_email" {
   value = google_service_account.terraform.email
 }
+
+output "workload_identity_provider" {
+  value = length(google_iam_workload_identity_pool_provider.github-actions) > 0 ? google_iam_workload_identity_pool_provider.github-actions[0].name : null
+}

--- a/modules/project/variables.tf
+++ b/modules/project/variables.tf
@@ -22,3 +22,9 @@ variable "add_required_es_roles" {
   description = "Add the roles required for Elasticsearch to the service account. Defaults to true."
   default     = true
 }
+
+variable "github_repository" {
+  description = "Name of the GitHub repository for the GitHub actions authentication"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
Can be used to authenticate the GitHub actions from a repository.