### PR TITLE
Add SA to deploy the ZTL cfg with TF from GH

### DIFF
--- a/modules/project/bucket.tf
+++ b/modules/project/bucket.tf
@@ -1,0 +1,22 @@
+# storage bucket for the terraform state
+
+resource "google_storage_bucket" "terraform" {
+  project                     = google_project.this.project_id
+  name                        = "${var.project_id}-terraform"
+  location                    = var.terraform_bucket_location
+  uniform_bucket_level_access = true
+}
+
+resource "google_storage_bucket_iam_member" "terraform_config" {
+  count = length(google_service_account.terraform_config) > 0 ? 1 : 0
+
+  bucket = google_storage_bucket.terraform.name
+  role   = "roles/storage.objectUser"
+  member = "serviceAccount:${google_service_account.terraform_config[0].email}"
+
+  condition {
+    title       = "Only config subfolder"
+    description = "Objects in the config/ subfolder"
+    expression  = "resource.name.startsWith('projects/_/buckets/${google_storage_bucket.terraform.name}/config/')"
+  }
+}

--- a/modules/project/iam.tf
+++ b/modules/project/iam.tf
@@ -1,0 +1,66 @@
+# service account for terraform / infra
+
+resource "google_service_account" "terraform_infra" {
+  project      = google_project.this.project_id
+  account_id   = "terraform-infra"
+  display_name = "Terraform Infra"
+  description  = "Service account for the Zentral infrastructure terraform deployment"
+}
+
+moved {
+  from = google_service_account.terraform
+  to   = google_service_account.terraform_infra
+}
+
+resource "google_project_iam_member" "terraform_infra" {
+  for_each = toset([
+    "roles/serviceusage.serviceUsageAdmin",
+    "roles/iam.roleAdmin",
+    "roles/iam.serviceAccountAdmin",
+    "roles/iam.serviceAccountUser",
+    "roles/resourcemanager.projectIamAdmin",
+    "roles/compute.admin",
+    "roles/servicenetworking.networksAdmin",
+    "roles/pubsub.admin",
+    "roles/redis.admin",
+    "roles/secretmanager.admin",
+    "roles/cloudsql.admin",
+    "roles/storage.admin",
+    "roles/cloudkms.admin",
+    # cloud function
+    "roles/appengine.appAdmin",
+    "roles/appengine.appCreator",
+    "roles/cloudscheduler.admin",
+    "roles/cloudfunctions.developer",
+    # monitoring
+    "roles/monitoring.alertPolicyEditor",
+    "roles/monitoring.notificationChannelEditor",
+    "roles/monitoring.uptimeCheckConfigEditor",
+  ])
+  project = google_project.this.project_id
+  role    = each.key
+  member  = "serviceAccount:${google_service_account.terraform_infra.email}"
+}
+
+moved {
+  from = google_project_iam_member.terraform
+  to   = google_project_iam_member.terraform_infra
+}
+
+resource "google_project_iam_member" "terraform_es" {
+  count   = var.add_required_es_roles ? 1 : 0
+  project = google_project.this.project_id
+  role    = "roles/iam.serviceAccountKeyAdmin"
+  member  = "serviceAccount:${google_service_account.terraform_infra.email}"
+}
+
+# service account for terraform / config
+
+resource "google_service_account" "terraform_config" {
+  count = var.github_config_repository != null ? 1 : 0
+
+  project      = google_project.this.project_id
+  account_id   = "terraform-config"
+  display_name = "Terraform Config"
+  description  = "Service account for the Zentral configuration terraform deployment"
+}

--- a/modules/project/outputs.tf
+++ b/modules/project/outputs.tf
@@ -13,10 +13,14 @@ output "number" {
   description = "The project number"
 }
 
-output "terraform_service_account_email" {
-  value = google_service_account.terraform.email
-}
-
 output "workload_identity_provider" {
   value = length(google_iam_workload_identity_pool_provider.github-actions) > 0 ? google_iam_workload_identity_pool_provider.github-actions[0].name : null
+}
+
+output "terraform_infra_service_account_email" {
+  value = google_service_account.terraform_infra.email
+}
+
+output "terraform_config_service_account_email" {
+  value = length(google_service_account.terraform_config) > 0 ? google_service_account.terraform_config[0].email : null
 }

--- a/modules/project/project.tf
+++ b/modules/project/project.tf
@@ -17,64 +17,6 @@ resource "google_project" "this" {
   }
 }
 
-# service account for terraform
-
-resource "google_service_account" "terraform" {
-  project      = google_project.this.project_id
-  account_id   = "terraform"
-  display_name = "Terraform"
-  description  = "Service account for the Zentral terraform deployment"
-}
-
-resource "google_project_iam_member" "terraform" {
-  for_each = toset([
-    "roles/serviceusage.serviceUsageAdmin",
-    "roles/iam.roleAdmin",
-    "roles/iam.serviceAccountAdmin",
-    "roles/iam.serviceAccountUser",
-    "roles/resourcemanager.projectIamAdmin",
-    "roles/compute.admin",
-    "roles/servicenetworking.networksAdmin",
-    "roles/pubsub.admin",
-    "roles/redis.admin",
-    "roles/secretmanager.admin",
-    "roles/cloudsql.admin",
-    "roles/storage.admin",
-    "roles/cloudkms.admin",
-    # cloud function
-    "roles/appengine.appAdmin",
-    "roles/appengine.appCreator",
-    "roles/cloudscheduler.admin",
-    "roles/cloudfunctions.developer",
-    # monitoring
-    "roles/monitoring.alertPolicyEditor",
-    "roles/monitoring.notificationChannelEditor",
-    "roles/monitoring.uptimeCheckConfigEditor",
-  ])
-  project = google_project.this.project_id
-  role    = each.key
-  member  = "serviceAccount:${google_service_account.terraform.email}"
-}
-
-resource "google_project_iam_member" "terraform_es" {
-  count   = var.add_required_es_roles ? 1 : 0
-  project = google_project.this.project_id
-  role    = "roles/iam.serviceAccountKeyAdmin"
-  member  = "serviceAccount:${google_service_account.terraform.email}"
-}
-
-# storage bucket for the terraform state
-
-resource "google_storage_bucket" "terraform" {
-  project                     = google_project.this.project_id
-  name                        = "${var.project_id}-terraform"
-  location                    = var.terraform_bucket_location
-  uniform_bucket_level_access = true
-}
-
-# the service usage API needs to be activated from outside the project
-# to allow the service account to activate the other ones
-
 resource "google_project_service" "service_usage" {
   project            = google_project.this.project_id
   service            = "serviceusage.googleapis.com"

--- a/modules/project/variables.tf
+++ b/modules/project/variables.tf
@@ -23,8 +23,14 @@ variable "add_required_es_roles" {
   default     = true
 }
 
-variable "github_repository" {
-  description = "Name of the GitHub repository for the GitHub actions authentication"
+variable "github_infra_repository" {
+  description = "Name of the GitHub infrastructure repository for the GitHub actions authentication"
+  type        = string
+  default     = null
+}
+
+variable "github_config_repository" {
+  description = "Name of the GitHub configuration repository for the GitHub actions authentication"
   type        = string
   default     = null
 }


### PR DESCRIPTION
We now have 2 separate Terraform Service Accounts. One always present to deploy the Zentral infrastructure. An optional second one to deploy the Zentral configuration. Those can be assumed by the jobs triggered by the 2 different GitHub repositories.